### PR TITLE
Output private key in format compatible for OpenSSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ go build
 ### Backup a private key
 
 To backup an SSH private key and generate a mnemonic phrase, run the following command:
-key2words backup <private_key_file>
+
+    key2words backup <private_key_file>
 
 Replace `<private_key_file>` with the path to your SSH private key file.
 
 Example:
-key2words backup ~/.ssh/id_ed25519
+
+    key2words backup ~/.ssh/id_ed25519
 
 The program will output the generated mnemonic phrase.
 
@@ -44,7 +46,8 @@ key2words restore <mnemonic>
 Replace `<mnemonic>` with the mnemonic phrase you obtained during the backup process.
 
 Example:
-key2words restore "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+
+    key2words restore "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
 The program will restore the private key and save it to the `restored_key` file, along with the corresponding public key in `restored_key.pub`.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/dfeldman/key2words
 go 1.21.2
 
 require (
-	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/crypto v0.22.0
 	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/term v0.19.0 // indirect
+	golang.org/x/term v0.19.0
+	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a h1:eU8j/ClY2Ty3qdHnn0TyW3ivFoPC/0F1gQZz8yTxbbE=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a/go.mod h1:v8eSC2SMp9/7FTKUncp7fH9IwPfw+ysMObcEz5FWheQ=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=

--- a/main.go
+++ b/main.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mikesmitty/edkey"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
 
 const (
-	privateKeyHeader = "PRIVATE KEY"
+	privateKeyHeader = "OPENSSH PRIVATE KEY"
 	outputFile       = "restored_key"
 )
 
@@ -188,7 +189,7 @@ func restoreKey(mnemonic string) ([]byte, []byte, error) {
 
 	privateKeyBytes := pem.EncodeToMemory(&pem.Block{
 		Type:  privateKeyHeader,
-		Bytes: privateKey,
+		Bytes: edkey.MarshalED25519PrivateKey(privateKey),
 	})
 
 	authorizedKeyBytes := ssh.MarshalAuthorizedKey(publicKey)


### PR DESCRIPTION
Here is a small patch that will output the SSH private key in a format that can be used with OpenSSH.

(I am not sure if that is the intention, but that is what I needed)

This patch is contributed under the same MIT license that the repo uses.